### PR TITLE
Update melting.lua

### DIFF
--- a/stats/effects/melting/melting.lua
+++ b/stats/effects/melting/melting.lua
@@ -7,6 +7,11 @@ function init()
 
 	self.tickTimer = 1.0
 	self.ticks=0
+	
+	if ( status.stat("fireResistance")	>= 1.0 ) then
+		effect.expire()
+		return
+	end
 
 	status.applySelfDamageRequest({
 		damageType = "IgnoresDef",


### PR DESCRIPTION
Fix for when the player has 100% fire res but not lava immunity, resulting in rapid damage ticks.